### PR TITLE
Add failure_cancels_group option to JobGroups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Run the required database migrations:
     $ rails generate delayed_job_groups_plugin:install
     $ rake db:migrate
 
+## Upgrading from 0.1.2
+run the following generator to create a migration for the new configuration column.
+
+    $ rails generate migration add_failure_cancels_group_to_delayed_job_groups failure_cancels_group:boolean
+    $ add `default: true, null: false` to the generated migration for the failure_cancels_group column
+    $ rake db:migrate
+
 ## Usage
 
 Creating a job group and queueing some jobs:
@@ -89,6 +96,12 @@ job_group = Delayed::JobGroups::JobGroup.create!
 # Do more stuff...
  
 job_group.cancel
+```
+
+Configuration to allow failed jobs not to cancel the group
+```ruby
+# We can optionally pass options that will allow jobs to fail without cancelling the group
+job_group = Delayed::JobGroups::JobGroup.create!(failure_cancels_group: false)
 ```
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run the required database migrations:
 run the following generator to create a migration for the new configuration column.
 
     $ rails generate migration add_failure_cancels_group_to_delayed_job_groups failure_cancels_group:boolean
-    $ add `default: true, null: false` to the generated migration for the failure_cancels_group column
+    # add `default: true, null: false` to the generated migration for the failure_cancels_group column
     $ rake db:migrate
 
 ## Usage

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'delayed_job', '>= 3.0'
   spec.add_dependency 'delayed_job_active_record', '>= 0.4'
 
+  spec.post_install_message = 'See https://github.com/salsify/delayed_job_groups_plugin#installation for upgrade/installation notes.'
+
   spec.add_development_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 4.1'])
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -8,7 +8,7 @@ module Delayed
 
       if Delayed::JobGroups::Compatibility.mass_assignment_security_enabled?
         attr_accessible :on_completion_job, :on_completion_job_options, :blocked, :on_cancellation_job,
-                        :on_cancellation_job_options
+                        :on_cancellation_job_options, :failure_cancels_group
       end
 
       serialize :on_completion_job
@@ -16,7 +16,7 @@ module Delayed
       serialize :on_cancellation_job
       serialize :on_cancellation_job_options, Hash
 
-      validates :queueing_complete, :blocked, inclusion: [true, false]
+      validates :queueing_complete, :blocked, :failure_cancels_group, inclusion: [true, false]
 
       if ActiveRecord::VERSION::MAJOR >= 4
         has_many :active_jobs, -> { where(failed_at: nil) }, class_name: Job

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -34,8 +34,8 @@ module Delayed
           # If a job in the job group fails, then cancel the whole job group.
           # Need to check that the job group is present since another
           # job may have concurrently cancelled it.
-          if job.in_job_group? && job.job_group
-            job.job_group.cancel if job.job_group.failure_cancels_group?
+          if job.in_job_group? && job.job_group && job.job_group.failure_cancels_group?
+            job.job_group.cancel
           end
         end
 

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -35,7 +35,7 @@ module Delayed
           # Need to check that the job group is present since another
           # job may have concurrently cancelled it.
           if job.in_job_group? && job.job_group
-            job.job_group.cancel
+            job.job_group.cancel if job.job_group.failure_cancels_group?
           end
         end
 

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/lib/generators/delayed_job_groups_plugin/templates/migration.rb
+++ b/lib/generators/delayed_job_groups_plugin/templates/migration.rb
@@ -21,6 +21,7 @@ class CreateDelayedJobGroups < ActiveRecord::Migration
       t.text :on_completion_job_options
       t.text :on_cancellation_job
       t.text :on_cancellation_job_options
+      t.boolean :failure_cancels_group, default: true, null: false
       t.boolean :queueing_complete, default: false, null: false
       t.boolean :blocked, default: false, null: false
     end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.text :on_completion_job_options
     t.text :on_cancellation_job
     t.text :on_cancellation_job_options
+    t.boolean :failure_cancels_group, default: true, null: false
     t.boolean :queueing_complete, default: false, null: false
     t.boolean :blocked, default: false, null: false
   end

--- a/spec/delayed/job_groups/job_group_spec.rb
+++ b/spec/delayed/job_groups/job_group_spec.rb
@@ -225,4 +225,26 @@ describe Delayed::JobGroups::JobGroup do
       running_job.should_not have_been_destroyed
     end
   end
+
+  describe "#failure_cancels_group?" do
+    let(:failure_cancels_group) { true }
+
+    before do
+      job_group.update_attribute(:failure_cancels_group, failure_cancels_group)
+    end
+
+    context "when failures should cancel the group" do
+      it "is true" do
+        expect(job_group.failure_cancels_group?).to be true
+      end
+    end
+
+    context "when failures should not cancel the group" do
+      let(:failure_cancels_group) { false }
+
+      it "is false" do
+        expect(job_group.failure_cancels_group?).to be false
+      end
+    end
+  end
 end

--- a/spec/delayed/job_groups/job_group_spec.rb
+++ b/spec/delayed/job_groups/job_group_spec.rb
@@ -230,11 +230,11 @@ describe Delayed::JobGroups::JobGroup do
     let(:failure_cancels_group) { true }
 
     before do
-      job_group.update_attribute(:failure_cancels_group, failure_cancels_group)
+      job_group.update_attributes!(failure_cancels_group: failure_cancels_group)
     end
 
     context "when failures should cancel the group" do
-      it "is true" do
+      it "returns true" do
         expect(job_group.failure_cancels_group?).to be true
       end
     end
@@ -242,7 +242,7 @@ describe Delayed::JobGroups::JobGroup do
     context "when failures should not cancel the group" do
       let(:failure_cancels_group) { false }
 
-      it "is false" do
+      it "returns false" do
         expect(job_group.failure_cancels_group?).to be false
       end
     end

--- a/spec/delayed/job_groups/plugin_spec.rb
+++ b/spec/delayed/job_groups/plugin_spec.rb
@@ -77,7 +77,7 @@ describe Delayed::JobGroups::Plugin do
   describe "job failures" do
 
     context "with failure_cancels_group enabled" do
-      it "cancel the group" do
+      it "cancels the group" do
         Delayed::Worker.max_attempts = 1
 
         job_group.enqueue(FailingJob.new)
@@ -97,9 +97,9 @@ describe Delayed::JobGroups::Plugin do
 
     context "with failure_cancels_group disabled" do
 
-      before { job_group.update_attribute(:failure_cancels_group, false) }
+      before { job_group.update_attributes!(failure_cancels_group: false) }
 
-      it "do not cancel the group" do
+      it "does not cancel the group" do
         Delayed::Worker.max_attempts = 1
 
         job_group.enqueue(FailingJob.new)


### PR DESCRIPTION
I thought it might be a useful feature to let `JobGroups` continue working despite individual job failures. This change introduces an attribute to job groups,  `failure_cancels_group` to control the behavior for the group when it detects a job failure. The default is `true` which is consistent with existing behavior. 
