### PR TITLE
Issue/dj lifecycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ matrix:
     # See https://github.com/rails/rails/pull/18306
     - rvm: 2.2.0
       env: RAILS_VERSION="~> 3.2.21" JRUBY_OPTS="$JRUBY_OPTS --debug"
+before_install:
+  - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-### 0.1.4(Unreleased)
+### 0.2.0
+* Change supported delayed job version
+* Clean up lifecycle management in plugin
 
 ### 0.1.3
 * Change supported rails version.

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir.glob('spec/**/*')
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'delayed_job', '>= 3.0'
+  spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 0.4'
 
   spec.post_install_message = 'See https://github.com/salsify/delayed_job_groups_plugin#installation for upgrade/installation notes.'

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '>= 2.14', '< 2.99'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'mime-types', '~> 2'
 
   if RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'jdbc-sqlite3'

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -7,19 +7,6 @@ module Delayed
   module JobGroups
     class Plugin < Delayed::Plugin
 
-      # Delayed job callbacks will be registered in a global Delayed::Lifecycle every time a
-      # Delayed::Worker is created. This creates problems in test runs that create
-      # multiple workers because we register the callbacks multiple times on the same
-      # global Lifecycle.
-      def self.callbacks(&block)
-        registered_lifecycles = Set.new
-        super do |lifecycle|
-          if registered_lifecycles.add?(lifecycle.object_id)
-            block.call(lifecycle)
-          end
-        end
-      end
-
       callbacks do |lifecycle|
         lifecycle.before(:error) do |worker, job|
           # If the job group has been cancelled then don't let the job be retried

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Removes unnecessary callback lifecycle management code and requires delayed_jobs 4.1 or higher.

prime: @jturkel 