### PR TITLE
Switched alias_method_chain to prepend.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - RAILS_VERSION="~> 4.1.16"
     - RAILS_VERSION="~> 4.2.9"
     - RAILS_VERSION="~> 5.0.6"
+    - RAILS_VERSION="~> 5.1.3"
 rvm:
   - 2.1.10
   - 2.2.8
@@ -27,3 +28,7 @@ matrix:
       env: RAILS_VERSION="~> 4.1.16"
     - rvm: jruby-9.1.13.0
       env: RAILS_VERSION="~> 5.0.6"
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.1.3"
+    - rvm: jruby-9.1.13.0
+      env: RAILS_VERSION="~> 5.1.3"

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = 'See https://github.com/salsify/delayed_job_groups_plugin#installation for upgrade/installation notes.'
 
-  spec.add_development_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.1'])
+  spec.add_development_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.2'])
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'
   # rspec < 3.5 requires rake < 11.0

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -19,7 +19,7 @@ module Delayed
       validates :queueing_complete, :blocked, :failure_cancels_group, inclusion: [true, false]
 
       if ActiveRecord::VERSION::MAJOR >= 4
-        has_many :active_jobs, -> { where(failed_at: nil) }, class_name: 'Job'
+        has_many :active_jobs, -> { where(failed_at: nil) }, class_name: '::Delayed::Job'
       else
         has_many :active_jobs, class_name: Job, conditions: {failed_at: nil}
       end

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -19,7 +19,7 @@ module Delayed
       validates :queueing_complete, :blocked, :failure_cancels_group, inclusion: [true, false]
 
       if ActiveRecord::VERSION::MAJOR >= 4
-        has_many :active_jobs, -> { where(failed_at: nil) }, class_name: Job
+        has_many :active_jobs, -> { where(failed_at: nil) }, class_name: 'Job'
       else
         has_many :active_jobs, class_name: Job, conditions: {failed_at: nil}
       end


### PR DESCRIPTION
Hey,

I've updated this gem to support Rails 5.1 by switching to `alias_method_chain` to use `Prepend`.

Note that this will break on versions of Ruby < 2.0, so I'd be happy to include a guard to ensure that the user is on a version of activerecord > 5 (which requires Ruby 2). Also happy to change the naming.

Let me know what you'd like, and thanks for making this awesome gem!