### PR TITLE
Drop Ruby 1.9 and 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,29 @@
 language: ruby
+sudo: false
 env:
-  - RAILS_VERSION="~> 3.2.22" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 4.0.13" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 4.1.16" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 4.2.7" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+  global:
+    - JRUBY_OPTS="$JRUBY_OPTS --debug"
+  matrix:
+    - RAILS_VERSION="~> 3.2.22.5"
+    - RAILS_VERSION="~> 4.0.13"
+    - RAILS_VERSION="~> 4.1.16"
+    - RAILS_VERSION="~> 4.2.9"
+    - RAILS_VERSION="~> 5.0.6"
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
   - 2.1.10
-  - 2.0.0-p648
-  - 1.9.3
-  - jruby-19mode
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - jruby-9.1.13.0
 matrix:
   exclude:
-    # See https://github.com/salsify/goldiloader/issues/22
-    - rvm: jruby-19mode
-      env: RAILS_VERSION="~> 4.2.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
-    # See https://github.com/rails/rails/pull/18306
-    - rvm: 2.2.0
-      env: RAILS_VERSION="~> 3.2.21" JRUBY_OPTS="$JRUBY_OPTS --debug"
-    # ruby 2.4 requires rails 4.2 or later
-    - rvm: 2.4.0
-      env: RAILS_VERSION="~> 3.2.22" JRUBY_OPTS="$JRUBY_OPTS --debug"
-    - rvm: 2.4.0
-      env: RAILS_VERSION="~> 4.0.13" JRUBY_OPTS="$JRUBY_OPTS --debug"
-    - rvm: 2.4.0
-      env: RAILS_VERSION="~> 4.1.16" JRUBY_OPTS="$JRUBY_OPTS --debug"
-    # rails 5 requires ruby 2.2 or later
-    - env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
-      rvm: 2.1.10
-    - env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
-      rvm: 2.0.0-p648
-    - env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
-      rvm: 1.9.3
-    - env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
-      rvm: jruby-19mode
-before_install:
-  - gem install bundler
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.0.6"
+    - rvm: 2.4.2
+      env: RAILS_VERSION="~> 3.2.22.5"
+    - rvm: 2.4.2
+      env: RAILS_VERSION="~> 4.0.13"
+    - rvm: 2.4.2
+      env: RAILS_VERSION="~> 4.1.16"
+    - rvm: jruby-9.1.13.0
+      env: RAILS_VERSION="~> 5.0.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.3.0 (unreleased)
+* Drop support for Ruby 1.9 and 2.0.
+
 ### 0.2.0
 * Change supported delayed job version
 * Clean up lifecycle management in plugin

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir.glob('spec/**/*')
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1'
+
   spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 0.4'
 

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
This PR drops Ruby 1.9 support in preparation of Rails 5.1 support (i.e. so we can just use `Module#prepend` rather than `alias_method_chain` for monkey patching). I also decided to drop Ruby 2.0 support so we can use required named parameters.

@atsheehan - you're prime