### PR TITLE
Changed class_name to be a string instead of class.

### DIFF
--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -28,7 +28,7 @@ module Delayed
       # Only delete dependent jobs that are unlocked so we can determine if there are in-flight jobs
       # for canceled job groups
       if ActiveRecord::VERSION::MAJOR >= 4
-        has_many :queued_jobs, -> { where(failed_at: nil, locked_by: nil) }, class_name: Job,
+        has_many :queued_jobs, -> { where(failed_at: nil, locked_by: nil) }, class_name: '::Delayed::Job',
                  dependent: :delete_all
       else
         has_many :queued_jobs, class_name: Job, conditions: {failed_at: nil, locked_by: nil},


### PR DESCRIPTION
Hey--I missed one deprecation warning for the 5.1 update. Classes are no longer supported as the type for the `class_name` argument on `belongs_to` and `has_many`. Just a deprecation warning in 5.1, but actually removed in 5.2.

We should be g2g after this!

Related to https://github.com/salsify/delayed_job_groups_plugin/pull/4