### PR TITLE
Bugfix for `on_completion_job` and `on_cancellation_job` YAML serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.4.1
+* Bugfix for `on_completion_job` and `on_cancellation_job` YAML serialization
+
 ### 0.4.0
 * Drop support for Ruby 2.0, 2.1 and 2.2.
 * Add support for Ruby 2.5.
@@ -19,5 +22,5 @@
 ### 0.1.2
 * Add configuration option to allow failed jobs not to cancel a group.
 
-### 0.1.1 
+### 0.1.1
 * Update the run_at for all jobs in a JobGroup when it's unblocked.

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'yaml_loader'
 
 module Delayed

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative 'yaml_loader'
 
 module Delayed
   module JobGroups
@@ -11,9 +12,9 @@ module Delayed
                         :on_cancellation_job_options, :failure_cancels_group
       end
 
-      serialize :on_completion_job
+      serialize :on_completion_job, Delayed::JobGroups::YamlLoader
       serialize :on_completion_job_options, Hash
-      serialize :on_cancellation_job
+      serialize :on_cancellation_job, Delayed::JobGroups::YamlLoader
       serialize :on_cancellation_job_options, Hash
 
       validates :queueing_complete, :blocked, :failure_cancels_group, inclusion: [true, false]

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/lib/delayed/job_groups/yaml_loader.rb
+++ b/lib/delayed/job_groups/yaml_loader.rb
@@ -1,0 +1,15 @@
+module Delayed
+ module JobGroups
+   module YamlLoader
+     def self.load(yaml)
+       return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
+       YAML.load_dj(yaml)
+     end
+
+     def self.dump(object)
+        return if object.nil?
+        YAML.dump(object)
+     end
+   end
+ end
+end

--- a/lib/delayed/job_groups/yaml_loader.rb
+++ b/lib/delayed/job_groups/yaml_loader.rb
@@ -1,15 +1,17 @@
-module Delayed
- module JobGroups
-   module YamlLoader
-     def self.load(yaml)
-       return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
-       YAML.load_dj(yaml)
-     end
+# frozen_string_literal: true
 
-     def self.dump(object)
+module Delayed
+  module JobGroups
+    module YamlLoader
+      def self.load(yaml)
+        return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
+        YAML.load_dj(yaml)
+      end
+
+      def self.dump(object)
         return if object.nil?
         YAML.dump(object)
-     end
-   end
- end
+      end
+    end
+  end
 end

--- a/lib/delayed/job_groups/yaml_loader.rb
+++ b/lib/delayed/job_groups/yaml_loader.rb
@@ -4,7 +4,7 @@ module Delayed
   module JobGroups
     module YamlLoader
       def self.load(yaml)
-        return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
+        return yaml unless yaml.is_a?(String) && /^---/.match(yaml)
         YAML.load_dj(yaml)
       end
 

--- a/lib/delayed_job_groups_plugin.rb
+++ b/lib/delayed_job_groups_plugin.rb
@@ -8,6 +8,7 @@ require 'delayed/job_groups/compatibility'
 require 'delayed/job_groups/job_extensions'
 require 'delayed/job_groups/job_group'
 require 'delayed/job_groups/plugin'
+require 'delayed/job_groups/yaml_loader'
 require 'delayed/job_groups/version'
 
 Delayed::Backend::ActiveRecord::Job.send(:include, Delayed::JobGroups::JobExtensions)

--- a/spec/delayed/job_groups/yaml_loader_spec.rb
+++ b/spec/delayed/job_groups/yaml_loader_spec.rb
@@ -1,0 +1,39 @@
+describe Delayed::JobGroups::YamlLoader do
+  class Foo; end
+
+  describe "#load" do
+    context "with a correct yaml object representation" do
+      let(:yaml) { '--- !ruby/object:Foo {}' }
+
+      it "deserializes properly" do
+        expect(Delayed::JobGroups::YamlLoader.load(yaml)).to be_a(Foo)
+      end
+    end
+
+    context "with an incorrect yaml object representation" do
+      let(:yaml) { 'foo' }
+
+      it "deserializes properly" do
+        expect(Delayed::JobGroups::YamlLoader.load(yaml)).to eq('foo')
+      end
+    end
+  end
+
+  describe "#dump" do
+    context "with an object" do
+      let(:object) { Foo.new }
+
+      it "deserializes properly" do
+        expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq("--- !ruby/object:Foo {}\n")
+      end
+    end
+
+    context "with a nil object" do
+      let(:object) { nil }
+
+      it "deserializes properly" do
+        expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/delayed/job_groups/yaml_loader_spec.rb
+++ b/spec/delayed/job_groups/yaml_loader_spec.rb
@@ -7,7 +7,7 @@ describe Delayed::JobGroups::YamlLoader do
     context "with a correct yaml object representation" do
       let(:yaml) { '--- !ruby/object:Foo {}' }
 
-      it "deserializes properly" do
+      it "deserializes from YAML properly" do
         expect(Delayed::JobGroups::YamlLoader.load(yaml)).to be_a(Foo)
       end
     end
@@ -16,7 +16,7 @@ describe Delayed::JobGroups::YamlLoader do
       let(:not_yaml1) { 'foo' }
       let(:not_yaml2) { 1 }
 
-      it "deserializes properly" do
+      it "deserializes from YAML properly" do
         expect(Delayed::JobGroups::YamlLoader.load(not_yaml1)).to eq('foo')
         expect(Delayed::JobGroups::YamlLoader.load(not_yaml2)).to eq(1)
       end
@@ -27,7 +27,7 @@ describe Delayed::JobGroups::YamlLoader do
     context "with an object" do
       let(:object) { Foo.new }
 
-      it "deserializes properly" do
+      it "serializes into YAML properly" do
         expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq("--- !ruby/object:Foo {}\n")
       end
     end
@@ -35,7 +35,7 @@ describe Delayed::JobGroups::YamlLoader do
     context "with a nil object" do
       let(:object) { nil }
 
-      it "deserializes properly" do
+      it "serializes into YAML properly" do
         expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq(nil)
       end
     end

--- a/spec/delayed/job_groups/yaml_loader_spec.rb
+++ b/spec/delayed/job_groups/yaml_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Delayed::JobGroups::YamlLoader do
   class Foo; end
 

--- a/spec/delayed/job_groups/yaml_loader_spec.rb
+++ b/spec/delayed/job_groups/yaml_loader_spec.rb
@@ -10,11 +10,13 @@ describe Delayed::JobGroups::YamlLoader do
       end
     end
 
-    context "with an incorrect yaml object representation" do
-      let(:yaml) { 'foo' }
+    context "with incorrect yaml object representations" do
+      let(:not_yaml1) { 'foo' }
+      let(:not_yaml2) { 1 }
 
       it "deserializes properly" do
-        expect(Delayed::JobGroups::YamlLoader.load(yaml)).to eq('foo')
+        expect(Delayed::JobGroups::YamlLoader.load(not_yaml1)).to eq('foo')
+        expect(Delayed::JobGroups::YamlLoader.load(not_yaml2)).to eq(1)
       end
     end
   end


### PR DESCRIPTION
*Background*
When a `Delayed::JobGroups::JobGroup` model is created and saved to the database, the values for `on_completion_job` and `on_cancellation_job` are serialized as  ruby objects via YAML. When the time comes to call these callback objects, the YAML object is taken from the database, parsed/deserialized, and instantiated.

*Problem*
For an unknown reason, whether by timing or sheer bad luck, sometimes the default way of deserializing the saved YAML text though the `Psych` library for `on_completion_job` and `on_cancellation_job` has an issue where the YAML is parsed correctly, but then the library’s `class_loader` is unable to find ruby class associated with its string counterpart. Initial efforts to rejigger autoloading/ class caching proved unfruitful.

*Solution*
The `delayed_jobs` library already solves this problem by overriding a large portion of Psych’s deserialization `ToRuby` process. In `psych_ext.rb`, it implements its own methods `visit_Psych_Nodes_Mapping` and `resolve_class`, which ultimately calls `klass_name.constantize` rather than using the `class_loader`. 

So, this PR adds a `YamlLoader` class that overrides the default `load` and `dump` methods used for Yaml serialization and deserialization, and instead calls `YAML.load_dj`, going through the same deserialization flow as `delayed_jobs`.

Prime: @jturkel 