### PR TITLE
Fix on_completion job firing when failure_cancels_group is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.4.3
+* Bugfix for `on_completion_job` when `failure_cancels_group` is set to false.
+
 ### 0.4.2
 * Add support for Rails 6.0.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ job_group.cancel
 
 Configuration to allow failed jobs not to cancel the group
 ```ruby
-# We can optionally pass options that will allow jobs to fail without cancelling the group
+# We can optionally pass options that will allow jobs to fail without cancelling the group.
+# This also allows the on_completion job to fire once all jobs have either succeeded or failed. 
 job_group = Delayed::JobGroups::JobGroup.create!(failure_cancels_group: false)
 ```
 


### PR DESCRIPTION
This fix allows the `on_completion` job to still fire when `failure_cancels_group` is set to false including cases where the last job queued/ran fails.