### PR TITLE
Fix job_group association with belongs_to_required_by_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+### 0.6.1
+* Fix job_group_id `belongs_to` behavior when `config.active_record.belongs_to_required_by_default` is enabled.
+
 ### 0.6.0
-* A support for Rails 6.1.
+* Add support for Rails 6.1.
 
 ### 0.5.0
 * Drop support for Ruby 2.3 and 2.4.

--- a/lib/delayed/job_groups/job_extensions.rb
+++ b/lib/delayed/job_groups/job_extensions.rb
@@ -15,7 +15,7 @@ module Delayed
           attr_accessible :job_group_id, :blocked
         end
 
-        belongs_to :job_group, class_name: 'Delayed::JobGroups::JobGroup'
+        belongs_to :job_group, class_name: 'Delayed::JobGroups::JobGroup', required: false
 
         class << self
           prepend ReadyToRunExtension

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/spec/delayed/job_groups/job_extensions_spec.rb
+++ b/spec/delayed/job_groups/job_extensions_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe "delayed job extensions" do
+  it "provides an optional job_group_id" do
+    job_group = Delayed::JobGroups::JobGroup.create!
+    expect(Delayed::Job.new(job_group_id: job_group.id)).to be_valid
+    expect(Delayed::Job.new).to be_valid
+  end
+end


### PR DESCRIPTION
With `belongs_to_required_by_default` set to true (the modern default), it becomes impossible to enqueue jobs without a group id. The fix is to explicitly define the relationship as optional. 

prime @jturkel 