### PR TITLE
Add ruby 3 to test matrix and drop ruby < 2.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:2.6.6
     working_directory: ~/delayed_job_groups
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.5.8-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.5.8-
+            - v1-gems-ruby-2.6.6-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.6.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.5.8-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.6.6-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -29,8 +29,10 @@ jobs:
     parameters:
       gemfile:
         type: string
+      ruby_version:
+        type: string
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:<< parameters.ruby_version >>
     environment:
       CIRCLE_TEST_REPORTS: "test-results"
       BUNDLE_GEMFILE: << parameters.gemfile >>
@@ -39,8 +41,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.5.8-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
-            - v1-gems-ruby-2.5.8-
+            - v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+            - v1-gems-ruby-<< parameters.ruby_version >>-
       - run:
           name: Install Gems
           command: |
@@ -49,7 +51,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.5.8-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+          key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -67,6 +69,13 @@ workflows:
           matrix:
             parameters:
               gemfile:
-              - "gemfiles/rails_5.2.gemfile"
-              - "gemfiles/rails_6.0.gemfile"
-              - "gemfiles/rails_6.1.gemfile"
+                - "gemfiles/rails_5.2.gemfile"
+                - "gemfiles/rails_6.0.gemfile"
+                - "gemfiles/rails_6.1.gemfile"
+              ruby_version:
+                - "2.6.6"
+                - "2.7.2"
+                - "3.0.0"
+            exclude:
+              - gemfile: "gemfiles/rails_5.2.gemfile"
+                ruby_version: "3.0.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,10 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - 'vendor/**/*'
-    - 'gemfiles/vendor/**/*'
+    - 'gemfiles/**/*'
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 0.7.0
+* Add support for ruby 3
+* Drop support for ruby < 2.6
 
 ### 0.6.2
 * Defer including extension until delayed_job_active_record is loaded

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'salsify_rubocop', '0.52.1.1'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'timecop'

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -1,7 +1,6 @@
-
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'delayed/job_groups/version'
 

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir.glob('spec/**/*')
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 4.1'

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 4.1'
 
-  spec.post_install_message = 'See https://github.com/salsify/delayed_job_groups_plugin#installation for upgrade/installation notes.'
+  spec.post_install_message = 'See https://github.com/salsify/delayed_job_groups_plugin#installation '\
+                              'for upgrade/installation notes.'
 
   spec.add_development_dependency 'appraisal'
   spec.add_dependency 'activerecord', '>= 5.2', '< 7'

--- a/lib/delayed/job_groups/compatibility.rb
+++ b/lib/delayed/job_groups/compatibility.rb
@@ -7,10 +7,6 @@ module Delayed
   module JobGroups
     module Compatibility
 
-      def self.mass_assignment_security_enabled?
-        defined?(::ActiveRecord::MassAssignmentSecurity)
-      end
-
     end
   end
 end

--- a/lib/delayed/job_groups/job_extensions.rb
+++ b/lib/delayed/job_groups/job_extensions.rb
@@ -11,9 +11,7 @@ module Delayed
       end
 
       included do
-        if Delayed::JobGroups::Compatibility.mass_assignment_security_enabled?
-          attr_accessible :job_group_id, :blocked
-        end
+        attr_accessible :job_group_id, :blocked if Delayed::JobGroups::Compatibility.mass_assignment_security_enabled?
 
         belongs_to :job_group, class_name: 'Delayed::JobGroups::JobGroup', required: false
 

--- a/lib/delayed/job_groups/job_extensions.rb
+++ b/lib/delayed/job_groups/job_extensions.rb
@@ -11,8 +11,6 @@ module Delayed
       end
 
       included do
-        attr_accessible :job_group_id, :blocked if Delayed::JobGroups::Compatibility.mass_assignment_security_enabled?
-
         belongs_to :job_group, class_name: 'Delayed::JobGroups::JobGroup', required: false
 
         class << self

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -8,11 +8,6 @@ module Delayed
 
       self.table_name = "#{ActiveRecord::Base.table_name_prefix}delayed_job_groups"
 
-      if Delayed::JobGroups::Compatibility.mass_assignment_security_enabled?
-        attr_accessible :on_completion_job, :on_completion_job_options, :blocked, :on_cancellation_job,
-                        :on_cancellation_job_options, :failure_cancels_group
-      end
-
       serialize :on_completion_job, Delayed::JobGroups::YamlLoader
       serialize :on_completion_job_options, Hash
       serialize :on_cancellation_job, Delayed::JobGroups::YamlLoader
@@ -67,7 +62,7 @@ module Delayed
           # zero will queue the job group's completion job and destroy the job group so
           # other jobs need to handle the job group having been destroyed already.
           job_group = where(id: job_group_id).lock(true).first
-          job_group.send(:complete) if job_group && job_group.send(:ready_for_completion?)
+          job_group.complete if job_group&.ready_for_completion?
         end
       end
 

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -30,6 +30,7 @@ module Delayed
       def mark_queueing_complete
         with_lock do
           raise 'JobGroup has already completed queueing' if queueing_complete?
+
           update_column(:queueing_complete, true)
           complete if ready_for_completion?
         end
@@ -73,6 +74,7 @@ module Delayed
       def self.has_pending_jobs?(job_group_ids) # rubocop:disable Naming/PredicateName
         job_group_ids = Array(job_group_ids)
         return false if job_group_ids.empty?
+
         Delayed::Job.where(job_group_id: job_group_ids, failed_at: nil).exists?
       end
 

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -62,7 +62,7 @@ module Delayed
           # zero will queue the job group's completion job and destroy the job group so
           # other jobs need to handle the job group having been destroyed already.
           job_group = where(id: job_group_id).lock(true).first
-          job_group.complete if job_group&.ready_for_completion?
+          job_group.send(:complete) if job_group&.send(:ready_for_completion?)
         end
       end
 
@@ -73,11 +73,11 @@ module Delayed
         Delayed::Job.where(job_group_id: job_group_ids, failed_at: nil).exists?
       end
 
+      private
+
       def ready_for_completion?
         queueing_complete? && !JobGroup.has_pending_jobs?(id) && !blocked?
       end
-
-      private
 
       def complete
         Delayed::Job.enqueue(on_completion_job, on_completion_job_options || {}) if on_completion_job

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -73,11 +73,11 @@ module Delayed
         Delayed::Job.where(job_group_id: job_group_ids, failed_at: nil).exists?
       end
 
-      private
-
       def ready_for_completion?
         queueing_complete? && !JobGroup.has_pending_jobs?(id) && !blocked?
       end
+
+      private
 
       def complete
         Delayed::Job.enqueue(on_completion_job, on_completion_job_options || {}) if on_completion_job

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -21,7 +21,7 @@ module Delayed
           # If a job in the job group fails, then cancel the whole job group.
           # Need to check that the job group is present since another
           # job may have concurrently cancelled it.
-          job.job_group.cancel if job.in_job_group? && job.job_group && job.job_group.failure_cancels_group?
+          job.job_group.cancel if job.in_job_group? && job.job_group&.failure_cancels_group?
         end
 
         lifecycle.after(:perform) do |_worker, job|

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -21,9 +21,7 @@ module Delayed
           # If a job in the job group fails, then cancel the whole job group.
           # Need to check that the job group is present since another
           # job may have concurrently cancelled it.
-          if job.in_job_group? && job.job_group && job.job_group.failure_cancels_group?
-            job.job_group.cancel
-          end
+          job.job_group.cancel if job.in_job_group? && job.job_group && job.job_group.failure_cancels_group?
         end
 
         lifecycle.after(:perform) do |_worker, job|

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.6.2'
+    VERSION = '0.7.0'
   end
 end

--- a/lib/delayed/job_groups/yaml_loader.rb
+++ b/lib/delayed/job_groups/yaml_loader.rb
@@ -5,11 +5,13 @@ module Delayed
     module YamlLoader
       def self.load(yaml)
         return yaml unless yaml.is_a?(String) && /^---/.match(yaml)
+
         YAML.load_dj(yaml)
       end
 
       def self.dump(object)
         return if object.nil?
+
         YAML.dump(object)
       end
     end

--- a/spec/delayed/job_groups/job_group_spec.rb
+++ b/spec/delayed/job_groups/job_group_spec.rb
@@ -50,6 +50,7 @@ describe Delayed::JobGroups::JobGroup do
       before { job_group.mark_queueing_complete }
 
       it { is_expected.to be_queueing_complete }
+
       it_behaves_like "the job group was completed"
     end
 
@@ -59,6 +60,7 @@ describe Delayed::JobGroups::JobGroup do
       before { job_group.mark_queueing_complete }
 
       it { is_expected.to be_queueing_complete }
+
       it_behaves_like "the job group was not completed"
     end
 
@@ -69,6 +71,7 @@ describe Delayed::JobGroups::JobGroup do
       end
 
       it { is_expected.to be_queueing_complete }
+
       it_behaves_like "the job group was not completed"
     end
   end
@@ -199,6 +202,7 @@ describe Delayed::JobGroups::JobGroup do
         end
 
         its(:blocked?) { is_expected.to be(false) }
+
         it_behaves_like "the job group was completed"
       end
     end

--- a/spec/delayed/job_groups/yaml_loader_spec.rb
+++ b/spec/delayed/job_groups/yaml_loader_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 describe Delayed::JobGroups::YamlLoader do
-  class Foo; end
-
   describe "#load" do
     context "with a correct yaml object representation" do
-      let(:yaml) { '--- !ruby/object:Foo {}' }
+      let(:yaml) { '--- !ruby/object:TestJobs::Foo {}' }
 
       it "deserializes from YAML properly" do
-        expect(Delayed::JobGroups::YamlLoader.load(yaml)).to be_a(Foo)
+        expect(Delayed::JobGroups::YamlLoader.load(yaml)).to be_a(TestJobs::Foo)
       end
     end
 
@@ -25,10 +23,10 @@ describe Delayed::JobGroups::YamlLoader do
 
   describe "#dump" do
     context "with an object" do
-      let(:object) { Foo.new }
+      let(:object) { TestJobs::Foo.new }
 
       it "serializes into YAML properly" do
-        expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq("--- !ruby/object:Foo {}\n")
+        expect(Delayed::JobGroups::YamlLoader.dump(object)).to eq("--- !ruby/object:TestJobs::Foo {}\n")
       end
     end
 

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module TestJobs
+  class Foo; end
+
+  class FailingJob
+    def perform
+      raise 'Test failure'
+    end
+  end
+
+  class NoOpJob
+    def perform
+
+    end
+  end
+
+  class CompletionJob
+    cattr_accessor :invoked
+
+    def perform
+      CompletionJob.invoked = true
+    end
+  end
+
+  class CancellationJob
+    cattr_accessor :invoked
+
+    def perform
+      CancellationJob.invoked = true
+    end
+  end
+end


### PR DESCRIPTION
* Added ruby 3 to test matrix
* Drop support for ruby < 2.6
* Updated rubocop to a version that can target ruby 2.6
  * Almost all of the changes are related to rubocop

prime: @jturkel 
cc: @salsify/laser-viper 