### PR TITLE
Prevent on_cancellation_job & on_completion_job deserialization failure blocking cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,23 @@ job_group.cancel
 Configuration to allow failed jobs not to cancel the group
 ```ruby
 # We can optionally pass options that will allow jobs to fail without cancelling the group.
-# This also allows the on_completion job to fire once all jobs have either succeeded or failed. 
+# This also allows the on_completion job to fire once all jobs have either succeeded or failed.
 job_group = Delayed::JobGroups::JobGroup.create!(failure_cancels_group: false)
 ```
+
+### Job Group Plugin Options
+
+The job group plugin can be configured in an initializer (e.g. `config/initializers/delayed_job_groups_plugin.rb`) as follows:
+
+```ruby
+Delayed::JobGroups.configure do |configuration|
+  configuration.error_reporter = Proc.new { |error| Bugsnag.notify(error) }
+end
+```
+
+The plugin supports the following options (all of which are optional):
+
+* `error_reporter` - a callback proc that accepts an `Exception` if the plugin encounters an unexpected error. This can be useful for reporting to an error monitoring system.
 
 ## Supported Platforms
 

--- a/lib/delayed/job_groups/configuration.rb
+++ b/lib/delayed/job_groups/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'delayed_job'
+require 'set'
+
+module Delayed
+  module JobGroups
+    class Configuration
+      attr_accessor :error_reporter
+    end
+  end
+end
+

--- a/lib/delayed/job_groups/configuration.rb
+++ b/lib/delayed/job_groups/configuration.rb
@@ -10,4 +10,3 @@ module Delayed
     end
   end
 end
-

--- a/lib/delayed/job_groups/configuration.rb
+++ b/lib/delayed/job_groups/configuration.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'delayed_job'
-require 'set'
-
 module Delayed
   module JobGroups
     class Configuration

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -56,7 +56,8 @@ module Delayed
           job = on_cancellation_job
           job_options = on_cancellation_job_options
         rescue StandardError => e
-          Delayed::Worker.logger.info("Failed to deserialize the on_cancellation_job or on_cancellation_job_options for job_group_id=#{id}. Skipping on_cancellation_job to clean up job group.")
+          Delayed::Worker.logger.info('Failed to deserialize the on_cancellation_job or on_cancellation_job_options ' \
+                                      "for job_group_id=#{id}. Skipping on_cancellation_job to clean up job group.")
           error_reporter.call(e) if error_reporter
         end
 
@@ -101,7 +102,8 @@ module Delayed
           job = on_completion_job
           job_options = on_completion_job_options
         rescue StandardError => e
-          Delayed::Worker.logger.info("Failed to deserialize the on_completion_job or on_completion_job_options for job_group_id=#{id}. Skipping on_completion_job to clean up job group.")
+          Delayed::Worker.logger.info('Failed to deserialize the on_completion_job or on_completion_job_options for ' \
+                                      "job_group_id=#{id}. Skipping on_completion_job to clean up job group.")
           error_reporter.call(e) if error_reporter
         end
 

--- a/lib/delayed_job_groups_plugin.rb
+++ b/lib/delayed_job_groups_plugin.rb
@@ -4,6 +4,7 @@ require 'active_support'
 require 'active_record'
 require 'delayed_job'
 require 'delayed_job_active_record'
+require 'delayed/job_groups/configuration'
 require 'delayed/job_groups/compatibility'
 require 'delayed/job_groups/job_extensions'
 require 'delayed/job_groups/job_group'
@@ -20,3 +21,19 @@ else
 end
 
 Delayed::Worker.plugins << Delayed::JobGroups::Plugin
+
+module Delayed
+  module JobGroups
+    @configuration = Delayed::JobGroups::Configuration.new
+
+    class << self
+      def configure
+        yield(configuration) if block_given?
+      end
+
+      def configuration
+        @configuration
+      end
+    end
+  end
+end

--- a/lib/delayed_job_groups_plugin.rb
+++ b/lib/delayed_job_groups_plugin.rb
@@ -27,12 +27,10 @@ module Delayed
     @configuration = Delayed::JobGroups::Configuration.new
 
     class << self
+      attr_reader :configuration
+
       def configure
         yield(configuration) if block_given?
-      end
-
-      def configuration
-        @configuration
       end
     end
   end

--- a/spec/delayed/job_groups/job_group_spec.rb
+++ b/spec/delayed/job_groups/job_group_spec.rb
@@ -148,6 +148,17 @@ describe Delayed::JobGroups::JobGroup do
         end
       end
 
+      let(:error_reporter) { Proc.new { |_error| } }
+
+      around do |example|
+        original_error_reporter = Delayed::JobGroups.configuration.error_reporter
+        Delayed::JobGroups.configuration.error_reporter = error_reporter
+        example.run
+        Delayed::JobGroups.configuration.error_reporter = original_error_reporter
+      end
+
+      before { allow(error_reporter).to receive(:call) }
+
       it "handles missing on_completion_job" do
         job_group = Delayed::JobGroups::JobGroup.create!(on_completion_job: Delayed::JobGroups::JobGroupTestHelper::OnCompletionJob.new,
                                                          on_completion_job_options: {})
@@ -162,6 +173,7 @@ describe Delayed::JobGroups::JobGroup do
 
         # Deserialization fails
         expect { Delayed::JobGroups::JobGroup.check_for_completion(job_group.id) }.not_to raise_error
+        expect(error_reporter).to have_received(:call)
         expect(job_group).to have_been_destroyed
       end
     end
@@ -267,6 +279,17 @@ describe Delayed::JobGroups::JobGroup do
                                              on_cancellation_job_options: {})
       end
 
+      let(:error_reporter) { Proc.new { |_error| } }
+
+      around do |example|
+        original_error_reporter = Delayed::JobGroups.configuration.error_reporter
+        Delayed::JobGroups.configuration.error_reporter = error_reporter
+        example.run
+        Delayed::JobGroups.configuration.error_reporter = original_error_reporter
+      end
+
+      before { allow(error_reporter).to receive(:call) }
+
       it "handles missing on_cancellation_job" do
         job_group = Delayed::JobGroups::JobGroup.create!(on_cancellation_job: Delayed::JobGroups::JobGroupTestHelper::OnCancellationJob.new,
                                                          on_cancellation_job_options: {})
@@ -278,6 +301,7 @@ describe Delayed::JobGroups::JobGroup do
 
         # Deserialization fails
         expect { job_group.cancel }.not_to raise_error
+        expect(error_reporter).to have_received(:call)
         expect(job_group).to have_been_destroyed
       end
     end

--- a/spec/delayed/job_groups/job_group_spec.rb
+++ b/spec/delayed/job_groups/job_group_spec.rb
@@ -142,11 +142,14 @@ describe Delayed::JobGroups::JobGroup do
     end
 
     context "on_completion_job refers to missing class" do
+      # The on_completion_job needs the class to be defined this way in order to serialize it
+      # rubocop:disable RSpec/LeakyConstantDeclaration,Style/ClassAndModuleChildren,Lint/ConstantDefinitionInBlock
       module Delayed::JobGroups::JobGroupTestHelper
         class OnCompletionJob
 
         end
       end
+      # rubocop:enable RSpec/LeakyConstantDeclaration,Style/ClassAndModuleChildren,Lint/ConstantDefinitionInBlock
 
       let(:error_reporter) { Proc.new { |_error| } }
 
@@ -160,7 +163,8 @@ describe Delayed::JobGroups::JobGroup do
       before { allow(error_reporter).to receive(:call) }
 
       it "handles missing on_completion_job" do
-        job_group = Delayed::JobGroups::JobGroup.create!(on_completion_job: Delayed::JobGroups::JobGroupTestHelper::OnCompletionJob.new,
+        on_completion_job = Delayed::JobGroups::JobGroupTestHelper::OnCompletionJob.new
+        job_group = Delayed::JobGroups::JobGroup.create!(on_completion_job: on_completion_job,
                                                          on_completion_job_options: {})
         job = Delayed::Job.create!(job_group_id: job_group.id)
         job_group.mark_queueing_complete
@@ -268,16 +272,14 @@ describe Delayed::JobGroups::JobGroup do
     end
 
     context "on_cancellation_job refers to missing class" do
+      # The on_cancellation_job needs the class to be defined this way in order to serialize it
+      # rubocop:disable RSpec/LeakyConstantDeclaration,Style/ClassAndModuleChildren,Lint/ConstantDefinitionInBlock
       module Delayed::JobGroups::JobGroupTestHelper
         class OnCancellationJob
 
         end
       end
-
-      subject(:job_group) do
-        Delayed::JobGroups::JobGroup.create!(on_cancellation_job: Delayed::JobGroups::JobGroupTestHelper::OnCancellationJob.new,
-                                             on_cancellation_job_options: {})
-      end
+      # rubocop:enable RSpec/LeakyConstantDeclaration,Style/ClassAndModuleChildren,Lint/ConstantDefinitionInBlock
 
       let(:error_reporter) { Proc.new { |_error| } }
 
@@ -291,7 +293,8 @@ describe Delayed::JobGroups::JobGroup do
       before { allow(error_reporter).to receive(:call) }
 
       it "handles missing on_cancellation_job" do
-        job_group = Delayed::JobGroups::JobGroup.create!(on_cancellation_job: Delayed::JobGroups::JobGroupTestHelper::OnCancellationJob.new,
+        on_cancellation_job = Delayed::JobGroups::JobGroupTestHelper::OnCancellationJob.new
+        job_group = Delayed::JobGroups::JobGroup.create!(on_cancellation_job: on_cancellation_job,
                                                          on_cancellation_job_options: {})
 
         # Remove the class for on_cancellation_job


### PR DESCRIPTION
This addresses https://github.com/salsify/delayed_job_groups_plugin/issues/22.
This skips enqueueing the on_cancellation_job or on_completion_job if there is an error deserializing it. Adds an optional proc, `error_reporter`, that accepts one argument (the raised error) when the job group encounters a deserialization error.

prime: @jturkel 
