### PR TITLE
Fix Rails 7.1 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 0.10.0
+## 0.10.1
+- Fix Rails 7.1 deprecation warnings
 
+## 0.10.0
 - Add support for Rails 7.1
 
 ## 0.9.0

--- a/lib/delayed/job_groups/compatibility.rb
+++ b/lib/delayed/job_groups/compatibility.rb
@@ -6,7 +6,12 @@ require 'active_record/version'
 module Delayed
   module JobGroups
     module Compatibility
+      ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING).release
+      VERSION_7_1 = ::Gem::Version.new('7.1.0')
 
+      def self.rails_7_1_or_greater?
+        ACTIVE_RECORD_VERSION >= VERSION_7_1
+      end
     end
   end
 end

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'yaml_loader'
+require_relative 'compatibility'
 
 module Delayed
   module JobGroups
@@ -8,10 +9,18 @@ module Delayed
 
       self.table_name = "#{ActiveRecord::Base.table_name_prefix}delayed_job_groups"
 
-      serialize :on_completion_job, Delayed::JobGroups::YamlLoader
-      serialize :on_completion_job_options, Hash
-      serialize :on_cancellation_job, Delayed::JobGroups::YamlLoader
-      serialize :on_cancellation_job_options, Hash
+      if Compatibility.rails_7_1_or_greater?
+        serialize :on_completion_job, coder: YAML, yaml: { unsafe_load: true }
+        serialize :on_completion_job_options, coder: YAML, type: Hash
+        serialize :on_cancellation_job, coder: YAML, yaml: { unsafe_load: true }
+        serialize :on_cancellation_job_options, coder: YAML, type: Hash
+      else
+        serialize :on_completion_job, Delayed::JobGroups::YamlLoader
+        serialize :on_completion_job_options, Hash
+        serialize :on_cancellation_job, Delayed::JobGroups::YamlLoader
+        serialize :on_cancellation_job_options, Hash
+      end
+
 
       validates :queueing_complete, :blocked, :failure_cancels_group, inclusion: [true, false]
 

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.10.0'
+    VERSION = '0.10.1'
   end
 end

--- a/lib/delayed/job_groups/yaml_loader.rb
+++ b/lib/delayed/job_groups/yaml_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This can be removed when we only support Rails 7.1+ because Rails 7.1 add a serialization
+# option for unsafe YAML loads
 module Delayed
   module JobGroups
     module YamlLoader


### PR DESCRIPTION
This PR fixes Rails 7.1 deprecation warnings like the following:

```
DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the coder as a keyword argument:

  serialize :on_completion_job, coder: Delayed::JobGroups::YamlLoader
 (called from <top (required)> at /Users/gsar/kluein/klue/config/application.rb:10)
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :on_completion_job_options, type: Hash
 (called from <top (required)> at /Users/gsar/kluein/klue/config/application.rb:10)
DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the coder as a keyword argument:

  serialize :on_cancellation_job, coder: Delayed::JobGroups::YamlLoader
 (called from <top (required)> at /Users/gsar/kluein/klue/config/application.rb:10)
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :on_cancellation_job_options, type: Hash
 (called from <top (required)> at /Users/gsar/kluein/klue/config/application.rb:10)
```
In Rails 7.1 the `serialize` method switched to taking options as keyword arguments rather than positional arguments. They also added native support for plumbing options through to the YAML serializer so someday we'll be able to drop the `Delayed::JobGroups::YamlLoader` workaround.

Fixes #30