### PR TITLE
Rails 7.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,16 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: cimg/ruby:3.0.6
+      - image: cimg/ruby:3.0.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_6.1.gemfile
     working_directory: ~/delayed_job_groups
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-3.0.6-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-3.0.6-
+            - v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
+            - v1-gems-ruby-3.0.7-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +20,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-3.0.6-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -72,8 +74,12 @@ workflows:
                 - gemfiles/rails_6.1.gemfile
                 - gemfiles/rails_7.0.gemfile
                 - gemfiles/rails_7.1.gemfile
+                - gemfiles/rails_7.2.gemfile
               ruby_version:
-                - 3.0.6
-                - 3.1.4
-                - 3.2.2
-                - 3.3.0
+                - 3.0.7
+                - 3.1.6
+                - 3.2.5
+                - 3.3.4
+            exclude:
+              - gemfile: gemfiles/rails_7.2.gemfile
+                ruby_version: 3.0.7

--- a/Appraisals
+++ b/Appraisals
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 appraise 'rails-6.1' do
-  gem 'activerecord', '~> 6.1.5'
-  gem 'activesupport', '~> 6.1.5'
+  gem 'activerecord', '~> 6.1.7'
+  gem 'activesupport', '~> 6.1.7'
+  gem 'sqlite3', '~> 1.7'
 end
 
 appraise 'rails-7.0' do
-  gem 'activerecord', '~> 7.0.2'
-  gem 'activesupport', '~> 7.0.2'
+  gem 'activerecord', '~> 7.0.8'
+  gem 'activesupport', '~> 7.0.8'
+  gem 'sqlite3', '~> 1.7'
 end
 
 appraise 'rails-7.1' do
-  gem 'activerecord', '~> 7.1.1'
-  gem 'activesupport', '~> 7.1.1'
+  gem 'activerecord', '~> 7.1.4'
+  gem 'activesupport', '~> 7.1.4'
+end
+
+appraise 'rails-7.2' do
+  gem 'activerecord', '~> 7.2.1'
+  gem 'activesupport', '~> 7.2.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.11.0
+- Add support for Rails 7.2.
+- 
 ## 0.10.1
 - Fix Rails 7.1 deprecation warnings
 

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 7.2'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 8.0'
   spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 4.1.8'
 

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.2"
-gem "activesupport", "~> 7.0.2"
+gem "activerecord", "~> 7.0.8"
+gem "activesupport", "~> 7.0.8"
+gem "sqlite3", "~> 1.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.1.1"
-gem "activesupport", "~> 7.1.1"
+gem "activerecord", "~> 7.1.4"
+gem "activesupport", "~> 7.1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,8 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.7"
-gem "activesupport", "~> 6.1.7"
-gem "sqlite3", "~> 1.7"
+gem "activerecord", "~> 7.2.1"
+gem "activesupport", "~> 7.2.1"
 
 gemspec path: "../"

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.10.1'
+    VERSION = '0.11.0'
   end
 end


### PR DESCRIPTION
This PR adds support for Rails 7.2. Nothing very interesting other than updating the test matrix and making sure we test with versions of sqlite3 supported by the various versions of Rails.

Fixes #35

@gremerritt - you're prime
