### PR TITLE
Add rails 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,15 +71,15 @@ workflows:
           matrix:
             parameters:
               gemfile:
-                - gemfiles/rails_6.1.gemfile
                 - gemfiles/rails_7.0.gemfile
                 - gemfiles/rails_7.1.gemfile
                 - gemfiles/rails_7.2.gemfile
+                - gemfiles/rails_8.0.gemfile
               ruby_version:
-                - 3.0.7
-                - 3.1.6
-                - 3.2.5
+                - 3.1.5
+                - 3.2.4
                 - 3.3.4
             exclude:
-              - gemfile: gemfiles/rails_7.2.gemfile
-                ruby_version: 3.0.7
+              - gemfile: gemfiles/rails_8.0.gemfile
+                ruby_version: 3.1.5
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
     docker:
       - image: cimg/ruby:3.0.7
     environment:
-      BUNDLE_GEMFILE: gemfiles/rails_6.1.gemfile
+      BUNDLE_GEMFILE: gemfiles/rails_7.0.gemfile
     working_directory: ~/delayed_job_groups
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
+            - v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_7.0.gemfile
             - v1-gems-ruby-3.0.7-
       - run:
           name: Install Gems
@@ -20,7 +20,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
+          key: v1-gems-ruby-3.0.7-{{ checksum "delayed_job_groups.gemspec" }}-{{ checksum "gemfiles/rails_7.0.gemfile
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'rails-6.1' do
-  gem 'activerecord', '~> 6.1.7'
-  gem 'activesupport', '~> 6.1.7'
-  gem 'sqlite3', '~> 1.7'
-end
-
 appraise 'rails-7.0' do
   gem 'activerecord', '~> 7.0.8'
   gem 'activesupport', '~> 7.0.8'
@@ -20,4 +14,9 @@ end
 appraise 'rails-7.2' do
   gem 'activerecord', '~> 7.2.1'
   gem 'activesupport', '~> 7.2.1'
+end
+
+appraise 'rails-8.0' do
+  gem 'activerecord', '~> 8.0.0'
+  gem 'activesupport', '~> 8.0.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+- Add support for Rails 8.0.
+- Drop support for Rails 6.1
+
 ## 0.11.0
 - Add support for Rails 7.2.
 - 

--- a/delayed_job_groups.gemspec
+++ b/delayed_job_groups.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 8.0'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 8.1'
   spec.add_dependency 'delayed_job', '>= 4.1'
   spec.add_dependency 'delayed_job_active_record', '>= 4.1.8'
 

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,8 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.7"
-gem "activesupport", "~> 6.1.7"
-gem "sqlite3", "~> 1.7"
+gem "activerecord", "~> 8.0.0"
+gem "activesupport", "~> 8.0.0"
 
 gemspec path: "../"

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.11.0'
+    VERSION = '0.12.0'
   end
 end


### PR DESCRIPTION
Adds Rails 8.0 support.
Pretty much a copy paste from [Activerecord-extensions's bump](https://github.com/salsify/activerecord-extensions/pull/117).