### PR TITLE
Move JobGroup Cancelling to After Failure DelayedJob Lifecycle Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.13.0
+- A failing job in a job group will now trigger the `on_cancellation_job` in after failure hook rather than before.
+
 ## 0.12.0
 - Add support for Rails 8.0.
 - Drop support for Rails 6.1

--- a/lib/delayed/job_groups/plugin.rb
+++ b/lib/delayed/job_groups/plugin.rb
@@ -17,7 +17,7 @@ module Delayed
           end
         end
 
-        lifecycle.before(:failure) do |_worker, job|
+        lifecycle.after(:failure) do |_worker, job|
           # If a job in the job group fails, then cancel the whole job group.
           # Need to check that the job group is present since another
           # job may have concurrently cancelled it.

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.12.0'
+    VERSION = '0.13.0'
   end
 end


### PR DESCRIPTION
Currently, the `on_cancellation_job` will trigger in the `before failure` hook of a job. This essentially makes it impossible for a job to perform any kind of cleanup on failure before the cancellation job is triggered.

This can lead to a race condition where other `before failure` hooks are running at the same time as the `on_cancellation job`.

This change proposes to move the cancellation to the `after failure` hook, allowing jobs to define cleanup logic in the `before_failure` hook, before the cancellation job is triggered.

@salsify/pim-core-backend 