### PR TITLE
Move On Cancellation Logic to After Failure Hook

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,6 +4,7 @@ appraise 'rails-7.0' do
   gem 'activerecord', '~> 7.0.8'
   gem 'activesupport', '~> 7.0.8'
   gem 'sqlite3', '~> 1.7'
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise 'rails-7.1' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0
+- Moves `on_cancellation` logic from the before delayed job lifecycle hook to the after hook.
+- Gem will now fail to load if `Delayed::Worker.destroy_failed_jobs` is set to true.
+- Wrapped the job group cancel hook in a lock to prevent concurrently failing jobs from enqueueing
+  multiple on cancellation jobs.
+
 ## 0.12.0
 - Add support for Rails 8.0.
 - Drop support for Rails 6.1

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 7.0.8"
 gem "activesupport", "~> 7.0.8"
 gem "sqlite3", "~> 1.7"
+gem 'concurrent-ruby', '1.3.4'
 
 gemspec path: "../"

--- a/lib/delayed/job_groups/errors.rb
+++ b/lib/delayed/job_groups/errors.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Delayed
+  module JobGroups
+    ConfigurationError = Class.new(StandardError)
+
+    class IncompatibleWithDelayedJobError < ConfigurationError
+      DEFAULT_MESSAGE = 'DelayedJobGroupsPlugin is incompatible with Delayed::Job ' \
+                        'when `destroy_failed_jobs` is set to `true`'
+
+      def initialize(msg = DEFAULT_MESSAGE)
+        super(msg)
+      end
+    end
+  end
+end

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -63,6 +63,8 @@ module Delayed
 
       def cancel
         with_lock do
+          return if destroyed?
+
           Delayed::Job.enqueue(on_cancellation_job, on_cancellation_job_options || {}) if on_cancellation_job
           destroy
         end

--- a/lib/delayed/job_groups/railtie.rb
+++ b/lib/delayed/job_groups/railtie.rb
@@ -4,6 +4,15 @@ module Delayed
   module JobGroups
     class Railtie < ::Rails::Railtie
       config.after_initialize do
+
+        # On cancellation checks are performed in the after failure delayed job lifecycle, however
+        # https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/worker.rb#L268 may
+        # delete jobs before the hook runs. This could cause a successful job in the same group to
+        # complete the group instead of the group being cancelled. Therefore, we must ensure that
+        # the Delayed::Worker.destroy_failed_jobs is set to false, guaranteeing that the group is
+        # never empty if failure occurs.
+        raise Delayed::JobGroups::IncompatibleWithDelayedJobError if Delayed::Worker.destroy_failed_jobs
+
         Delayed::Backend::ActiveRecord::Job.include(Delayed::JobGroups::JobExtensions)
       end
     end

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.12.0'
+    VERSION = '0.13.0'
   end
 end

--- a/lib/delayed_job_groups_plugin.rb
+++ b/lib/delayed_job_groups_plugin.rb
@@ -4,6 +4,7 @@ require 'active_support'
 require 'active_record'
 require 'delayed_job'
 require 'delayed_job_active_record'
+require 'delayed/job_groups/errors'
 require 'delayed/job_groups/compatibility'
 require 'delayed/job_groups/complete_stuck_job_groups_job'
 require 'delayed/job_groups/job_extensions'
@@ -18,6 +19,7 @@ if defined?(Rails::Railtie)
 else
   # Do the same as in the railtie
   Delayed::Backend::ActiveRecord::Job.include(Delayed::JobGroups::JobExtensions)
+  raise Delayed::JobGroups::IncompatibleWithDelayedJobError if Delayed::Worker.destroy_failed_jobs
 end
 
 Delayed::Worker.plugins << Delayed::JobGroups::Plugin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,11 @@ end
 
 require 'rspec/its'
 require 'database_cleaner'
+require 'delayed_job'
+
+Delayed::Worker.read_ahead = 1
+Delayed::Worker.destroy_failed_jobs = false
+
 require 'delayed_job_groups_plugin'
 require 'factory_bot'
 require 'yaml'
@@ -22,9 +27,6 @@ spec_dir = File.dirname(__FILE__)
 Dir["#{spec_dir}/support/**/*.rb"].sort.each { |f| require f }
 
 FileUtils.makedirs('log')
-
-Delayed::Worker.read_ahead = 1
-Delayed::Worker.destroy_failed_jobs = false
 
 Delayed::Worker.logger = Logger.new('log/test.log')
 Delayed::Worker.logger.level = Logger::DEBUG


### PR DESCRIPTION
In order to allow individual jobs in the JobGroup to perform cleanup activities upon job failure, a JobGroups on cancellation job must be enqueued in the after failure  delayed job lifecycle hook. If both were to be performed in the same hook, the job's failure hook and the on cancellation job may run at the same time since hook execution  order is never guaranteed. This is particular important if the on cancellation job  depends on state set in the failure hook of an individual job.

This also forces the Delayed::Worker.destroy_failed_jobs to be set to false in order to prevent a race condition where a JobGroup could be completed (instead of cancelled) if a successful job occurs at the same time as a failing job.

prime @jturkel 