### PR TITLE
Move On Cancellation Logic to After Failure Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0
+### Breaking Changes
+- This library will fail to load if `Delayed::Worker.destroy_failed_jobs` is set to true.
+  Delayed::Job sets this option to true by default, you will need to configure it to false
+  in order to include this library.
+### Changes
+- Moves `on_cancellation` logic from the before delayed job lifecycle hook to the after hook.
+- Wrapped the job group cancel hook in a lock to prevent concurrently failing jobs from enqueueing
+  multiple on cancellation jobs.
+
 ## 0.14.0
 - Reverts changes made in version 0.13.
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,22 @@ Run the required database migrations:
     $ rails generate delayed_job_groups_plugin:install
     $ rake db:migrate
 
+## Upgrading from 0.14.0
+
+This library is now incompatible with Delayed::Job's default setting for `destroy_failed_jobs`.
+In order to use Delayed Job Groups, you must set it to false while configuring Delayed::Job:
+
+```ruby
+Delayed::Worker.destroy_failed_jobs = false
+```
+
 ## Upgrading from 0.1.2
 run the following generator to create a migration for the new configuration column.
 
     $ rails generate migration add_failure_cancels_group_to_delayed_job_groups failure_cancels_group:boolean
     # add `default: true, null: false` to the generated migration for the failure_cancels_group column
     $ rake db:migrate
+
 
 ## Usage
 

--- a/lib/delayed/job_groups/errors.rb
+++ b/lib/delayed/job_groups/errors.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Delayed
+  module JobGroups
+    ConfigurationError = Class.new(StandardError)
+
+    class IncompatibleWithDelayedJobError < ConfigurationError
+      DEFAULT_MESSAGE = 'DelayedJobGroupsPlugin is incompatible with Delayed::Job ' \
+                        'when `destroy_failed_jobs` is set to `true`'
+
+      def initialize(msg = DEFAULT_MESSAGE)
+        super(msg)
+      end
+    end
+  end
+end

--- a/lib/delayed/job_groups/job_group.rb
+++ b/lib/delayed/job_groups/job_group.rb
@@ -63,6 +63,8 @@ module Delayed
 
       def cancel
         with_lock do
+          return if destroyed?
+
           Delayed::Job.enqueue(on_cancellation_job, on_cancellation_job_options || {}) if on_cancellation_job
           destroy
         end

--- a/lib/delayed/job_groups/railtie.rb
+++ b/lib/delayed/job_groups/railtie.rb
@@ -4,6 +4,15 @@ module Delayed
   module JobGroups
     class Railtie < ::Rails::Railtie
       config.after_initialize do
+
+        # On cancellation checks are performed in the after failure delayed job lifecycle, however
+        # https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/worker.rb#L268 may
+        # delete jobs before the hook runs. This could cause a successful job in the same group to
+        # complete the group instead of the group being cancelled. Therefore, we must ensure that
+        # the Delayed::Worker.destroy_failed_jobs is set to false, guaranteeing that the group is
+        # never empty if failure occurs.
+        raise Delayed::JobGroups::IncompatibleWithDelayedJobError if Delayed::Worker.destroy_failed_jobs
+
         Delayed::Backend::ActiveRecord::Job.include(Delayed::JobGroups::JobExtensions)
       end
     end

--- a/lib/delayed/job_groups/railtie.rb
+++ b/lib/delayed/job_groups/railtie.rb
@@ -11,7 +11,9 @@ module Delayed
         # complete the group instead of the group being cancelled. Therefore, we must ensure that
         # the Delayed::Worker.destroy_failed_jobs is set to false, guaranteeing that the group is
         # never empty if failure occurs.
-        raise Delayed::JobGroups::IncompatibleWithDelayedJobError if Delayed::Worker.destroy_failed_jobs
+        if Delayed::Worker.destroy_failed_jobs && ActiveRecord::Base.connection.table_exists?(:delayed_job_groups)
+          raise Delayed::JobGroups::IncompatibleWithDelayedJobError
+        end
 
         Delayed::Backend::ActiveRecord::Job.include(Delayed::JobGroups::JobExtensions)
       end

--- a/lib/delayed/job_groups/version.rb
+++ b/lib/delayed/job_groups/version.rb
@@ -2,6 +2,6 @@
 
 module Delayed
   module JobGroups
-    VERSION = '0.14.0'
+    VERSION = '1.0.0'
   end
 end

--- a/lib/delayed_job_groups_plugin.rb
+++ b/lib/delayed_job_groups_plugin.rb
@@ -4,6 +4,7 @@ require 'active_support'
 require 'active_record'
 require 'delayed_job'
 require 'delayed_job_active_record'
+require 'delayed/job_groups/errors'
 require 'delayed/job_groups/compatibility'
 require 'delayed/job_groups/complete_stuck_job_groups_job'
 require 'delayed/job_groups/job_extensions'
@@ -18,6 +19,7 @@ if defined?(Rails::Railtie)
 else
   # Do the same as in the railtie
   Delayed::Backend::ActiveRecord::Job.include(Delayed::JobGroups::JobExtensions)
+  raise Delayed::JobGroups::IncompatibleWithDelayedJobError if Delayed::Worker.destroy_failed_jobs
 end
 
 Delayed::Worker.plugins << Delayed::JobGroups::Plugin

--- a/lib/generators/delayed_job_groups_plugin/install_generator.rb
+++ b/lib/generators/delayed_job_groups_plugin/install_generator.rb
@@ -18,5 +18,37 @@ module DelayedJobGroupsPlugin
       ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
 
+    def create_initializer
+      initializer_file = File.join('config/initializers', 'delayed_job_config.rb')
+      configuration_on_matcher = /Delayed::Worker\.destroy_failed_jobs\s*=\s*true/
+      configuration_off_matcher = /Delayed::Worker\.destroy_failed_jobs\s*=\s*false/
+
+      say 'Attempting to initialize delayed_job_config initializer...', :green
+
+      if File.exist?(initializer_file)
+        say 'delayed_job_config initializer already exists... checking destroy_failed_jobs options', :green
+        contents = File.read(initializer_file)
+        if contents.match(configuration_on_matcher)
+          say 'Delayed::Worker.destroy_failed_jobs is set to true', :red
+          say 'This library requires the option to be set to false, updating config now!', :yellow
+
+          gsub_file initializer_file, configuration_on_matcher, 'Delayed::Worker.destroy_failed_jobs = false'
+        elsif contents.match(configuration_off_matcher)
+          say 'Delayed::Worker.destroy_failed_jobs is set to false; nothing to do!', :green
+        else
+          say 'Delayed::Worker.destroy_failed_jobs is not set'
+          say 'This library requires the option to be set to false, updating config now!', :yellow
+          inject_into_file initializer_file, "Delayed::Worker.destroy_failed_jobs = false\n"
+        end
+      else
+        create_file initializer_file do
+          <<~RUBY
+            # frozen_string_literal: true
+
+            Delayed::Worker.destroy_failed_jobs = false
+          RUBY
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,11 @@ end
 
 require 'rspec/its'
 require 'database_cleaner'
+require 'delayed_job'
+
+Delayed::Worker.read_ahead = 1
+Delayed::Worker.destroy_failed_jobs = false
+
 require 'delayed_job_groups_plugin'
 require 'factory_bot'
 require 'yaml'
@@ -22,9 +27,6 @@ spec_dir = File.dirname(__FILE__)
 Dir["#{spec_dir}/support/**/*.rb"].sort.each { |f| require f }
 
 FileUtils.makedirs('log')
-
-Delayed::Worker.read_ahead = 1
-Delayed::Worker.destroy_failed_jobs = false
 
 Delayed::Worker.logger = Logger.new('log/test.log')
 Delayed::Worker.logger.level = Logger::DEBUG


### PR DESCRIPTION
Addressed this [issue](https://github.com/salsify/delayed_job_groups_plugin/issues/40).

Re-release https://github.com/salsify/delayed_job_groups_plugin/pull/39 under a new major version

prime @jturkel @erikkessler1 